### PR TITLE
doc update

### DIFF
--- a/Resources/config/doctrine/Url.orm.yml
+++ b/Resources/config/doctrine/Url.orm.yml
@@ -26,3 +26,4 @@ Berriart\Bundle\SitemapBundle\Entity\Url:
         images:
             targetEntity: Berriart\Bundle\SitemapBundle\Entity\ImageUrl
             mappedBy: url
+            cascade: ['persist', 'remove']

--- a/Resources/doc/manage_sitemap.md
+++ b/Resources/doc/manage_sitemap.md
@@ -57,7 +57,7 @@ use Berriart\Bundle\SitemapBundle\Entity\ImageUrl;
         $image->setGeoLocation($geoLocation);
         $image->setTitle($title);
         $image->setLicense($license);
-        $image->setUrl($url);
+        $url->addImageUrl($url);
         // Add to the sitemap
         // (to complete the insert to db you must call save method, same on update or delete)
         $sitemap->add($url);

--- a/Resources/doc/populating_sitemap.md
+++ b/Resources/doc/populating_sitemap.md
@@ -137,7 +137,7 @@ use absolute urls.
 
 After providers are in place and registered, time to run the generation command:
 
-    > php app/console berriart:sitemap:populate
+    > php app/console berriart:sitemap:populate --no-debug
 
 
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "symfony/framework-bundle": "2.*",
         "doctrine/common": ">=2.0",
-        "symfony/doctrine-bundle": "*",
+        "doctrine/doctrine-bundle": "*"
     },
     "autoload": {
         "psr-0": { "Berriart\\Bundle\\SitemapBundle": "" }


### PR DESCRIPTION
Hello,

Trying to generate really big sitemap (~50000 urls) exceeds default 128mb memory limit. Reason is SQLLogger, that is a [common case](https://groups.google.com/forum/?fromgroups#!topic/symfony-devs/vfP6XBDvZcg) for symfony2 commands. 
Updated doc to help other developers not to fail same as I did :)