### PR TITLE
Remove invalid/unneeded method in Sitemap

### DIFF
--- a/Manager/Sitemap.php
+++ b/Manager/Sitemap.php
@@ -68,9 +68,4 @@ class Sitemap
     {
         $this->repository->flush();
     }
-
-    public function lastmod($page)
-    {
-        return $this->repository->getLastmod($page);
-    }
 }


### PR DESCRIPTION
There was a method in Manager/Sitemap.php that didn't work, or have a valid function in the context. It looked like it was a copy/paste error.