### PR TITLE
Fix doctrine bundle reference - now in doctrine namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "symfony/framework-bundle": "2.*",
         "doctrine/common": ">=2.0",
-        "symfony/doctrine-bundle": "*",
+        "doctrine/doctrine-bundle": "*"
     },
     "autoload": {
         "psr-0": { "Berriart\\Bundle\\SitemapBundle": "" }


### PR DESCRIPTION
Composer file had a reference to symfony/doctrine-bundle which has since been replaced with doctrine/doctrine-bundle.